### PR TITLE
Add upstream sync documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,10 @@ instrument.mjs
 # nix build output
 /infrastructure/result
 
+# Local upstream tools
+/.topos/*
+!.topos/README.md
+!.topos/update-from-upstream.sh
+
 # Database dumps
 /dumps

--- a/.topos/README.md
+++ b/.topos/README.md
@@ -1,0 +1,33 @@
+# CatColab Fork Guide
+
+This directory documents how this repository diverges from the upstream
+[ToposInstitute/CatColab](https://github.com/ToposInstitute/CatColab) project.
+It collects auxiliary scripts and notes so that updates from upstream can be
+managed with minimal friction.
+
+## Differences from upstream
+
+The main branch of this repository tracks `ToposInstitute/CatColab:main` with a
+few additional developer conveniences:
+
+- Flox environment files under `.flox/` for deterministic tooling.
+- A `justfile` and `justfile-tests.yml` workflow for quick project setup and
+  CI checks.
+- Local notes in `CLAUDE.md`.
+
+Keeping these files separate helps reduce merge conflicts when pulling in
+changes from upstream.
+
+## Updating from upstream
+
+Run `./.topos/update-from-upstream.sh` to fetch and merge the latest commits from
+`ToposInstitute/CatColab`. The script will add the `topos` remote if it does not
+already exist.
+
+```
+# update local main branch
+./.topos/update-from-upstream.sh
+```
+
+After merging, resolve any conflicts, run the project checks, and commit as
+usual.

--- a/.topos/update-from-upstream.sh
+++ b/.topos/update-from-upstream.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE="topos"
+BRANCH="main"
+
+if ! git remote | grep -q "^${REMOTE}$"; then
+  git remote add ${REMOTE} https://github.com/ToposInstitute/CatColab.git
+fi
+
+git fetch ${REMOTE}
+git merge --ff-only ${REMOTE}/${BRANCH}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ cargo clippy
 Try to remember to run these commands before making a PR. (If you forget, the CI
 will remind you.)
 
+### Keeping in sync with upstream
+
+This fork tracks the public repository
+[ToposInstitute/CatColab](https://github.com/ToposInstitute/CatColab).
+Helper scripts and notes for merging updates are stored in the
+[`\.topos`](./.topos) directory. To pull the latest upstream changes run:
+
+```bash
+./.topos/update-from-upstream.sh
+```
+
 ## For mathematicians
 
 As the name suggests, CatColab is based on mathematical ideas from category


### PR DESCRIPTION
## Summary
- mention `.topos` helper utilities in the main README
- ignore `.topos` workspace state in .gitignore
- enforce fast‑forward merges in update script

## Testing
- `pnpm test` in `packages/frontend` *(fails: connection refused)*
- `cargo test` in `packages/backend` *(interrupted due to toolchain download)*

------
https://chatgpt.com/codex/tasks/task_e_6842d54e8a108332b124444d21fa2ce1